### PR TITLE
Minor type fixes

### DIFF
--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -3,7 +3,7 @@ import { RxDatabase } from 'rxdb';
 import Context from './context';
 
 interface ProviderProps {
-	db: RxDatabase;
+	db?: RxDatabase;
 	idAttribute?: string;
 }
 


### PR DESCRIPTION
Property `db` of `<Provider/>`  made optional to properly reflect lazy instantiation