### PR TITLE
useRxQuery & useRxData provide currentPage status

### DIFF
--- a/src/useRxQuery.ts
+++ b/src/useRxQuery.ts
@@ -165,6 +165,7 @@ const reducer = <T>(state: RxState<T>, action: AnyAction<T>): RxState<T> => {
 				result: [],
 				isFetching: true,
 				limit: action.pageSize,
+				page: 1,
 			};
 		case ActionType.FetchMore:
 			return {
@@ -290,7 +291,7 @@ function useRxQuery<T>(
 			return;
 		}
 		dispatch({ type: ActionType.Reset, pageSize });
-	}, [pageSize, state.limit]);
+	}, [pageSize, state.limit, paginationMode]);
 
 	useEffect(() => {
 		if (!isRxQuery(query)) {

--- a/src/useRxQuery.ts
+++ b/src/useRxQuery.ts
@@ -24,6 +24,12 @@ export interface RxQueryResult<T> {
 	pageCount: number;
 
 	/**
+	 * The number of the current page.
+	 * Relevant in "infinite scroll" pagination mode
+	 */
+	currentPage: number;
+
+	/**
 	 * Allows consumer to request a specific page of results.
 	 * Relevant in "traditional" pagination mode
 	 */
@@ -164,6 +170,7 @@ const reducer = <T>(state: RxState<T>, action: AnyAction<T>): RxState<T> => {
 			return {
 				...state,
 				isFetching: true,
+				page: state.page + 1,
 				limit: state.limit + action.pageSize,
 			};
 		case ActionType.FetchPage:
@@ -239,7 +246,8 @@ function useRxQuery<T>(
 
 	const initialState = {
 		result: [],
-		page: startingPage,
+		page:
+			paginationMode === PaginationMode.InfiniteScroll ? 1 : startingPage,
 		limit: paginationMode === PaginationMode.InfiniteScroll ? pageSize : 0,
 		isFetching: true,
 		isExhausted: false,
@@ -358,6 +366,7 @@ function useRxQuery<T>(
 		isFetching: state.isFetching,
 		isExhausted: state.isExhausted,
 		pageCount: state.pageCount,
+		currentPage: state.page,
 		fetchPage,
 		fetchMore,
 		resetList,

--- a/src/useRxQuery.ts
+++ b/src/useRxQuery.ts
@@ -14,6 +14,7 @@ export interface RxQueryResult<T> {
 
 	/**
 	 * Indicates that all available results have been already fetched.
+	 * Relevant in "infinite scroll" pagination mode
 	 */
 	isExhausted: boolean;
 
@@ -106,7 +107,6 @@ interface RxState<T> {
 	result: T[] | RxDocument<T>[];
 	isFetching: boolean;
 	isExhausted: boolean;
-	limit: number;
 	page: number | undefined;
 	pageCount: number;
 }
@@ -122,12 +122,10 @@ enum ActionType {
 
 interface ResetAction {
 	type: ActionType.Reset;
-	pageSize: number;
 }
 
 interface FetchMoreAction {
 	type: ActionType.FetchMore;
-	pageSize: number;
 }
 
 interface FetchPageAction {
@@ -143,6 +141,8 @@ interface CountPagesAction {
 interface FetchSuccessAction<T> {
 	type: ActionType.FetchSuccess;
 	docs: T[];
+	paginationMode: PaginationMode;
+	pageSize: number;
 }
 
 interface QueryChangedAction {
@@ -164,7 +164,6 @@ const reducer = <T>(state: RxState<T>, action: AnyAction<T>): RxState<T> => {
 				...state,
 				result: [],
 				isFetching: true,
-				limit: action.pageSize,
 				page: 1,
 			};
 		case ActionType.FetchMore:
@@ -172,7 +171,6 @@ const reducer = <T>(state: RxState<T>, action: AnyAction<T>): RxState<T> => {
 				...state,
 				isFetching: true,
 				page: state.page + 1,
-				limit: state.limit + action.pageSize,
 			};
 		case ActionType.FetchPage:
 			return {
@@ -190,7 +188,12 @@ const reducer = <T>(state: RxState<T>, action: AnyAction<T>): RxState<T> => {
 				...state,
 				result: action.docs,
 				isFetching: false,
-				isExhausted: !state.limit || action.docs.length < state.limit,
+				isExhausted:
+					action.paginationMode === PaginationMode.InfiniteScroll
+						? action.docs.length < state.page * action.pageSize
+						: action.paginationMode === PaginationMode.None
+						? true
+						: false,
 			};
 		case ActionType.QueryChanged:
 			return {
@@ -245,11 +248,10 @@ function useRxQuery<T>(
 
 	const paginationMode = getPaginationMode(options);
 
-	const initialState = {
+	const initialState: RxState<T> = {
 		result: [],
 		page:
 			paginationMode === PaginationMode.InfiniteScroll ? 1 : startingPage,
-		limit: paginationMode === PaginationMode.InfiniteScroll ? pageSize : 0,
 		isFetching: true,
 		isExhausted: false,
 		pageCount: 0,
@@ -280,18 +282,18 @@ function useRxQuery<T>(
 		if (state.isFetching || state.isExhausted) {
 			return;
 		}
-		dispatch({ type: ActionType.FetchMore, pageSize });
-	}, [state.limit, state.isFetching, state.isExhausted, pageSize]);
+		dispatch({ type: ActionType.FetchMore });
+	}, [state.isFetching, state.isExhausted]);
 
 	const resetList = useCallback(() => {
 		if (paginationMode !== PaginationMode.InfiniteScroll) {
 			return;
 		}
-		if (state.limit <= pageSize) {
+		if (state.page === 1) {
 			return;
 		}
-		dispatch({ type: ActionType.Reset, pageSize });
-	}, [pageSize, state.limit, paginationMode]);
+		dispatch({ type: ActionType.Reset });
+	}, [state.page, paginationMode]);
 
 	useEffect(() => {
 		if (!isRxQuery(query)) {
@@ -305,7 +307,7 @@ function useRxQuery<T>(
 		}
 
 		if (paginationMode === PaginationMode.InfiniteScroll) {
-			_query = _query.limit(state.limit);
+			_query = _query.limit(state.page * pageSize);
 		}
 
 		if (sortBy) {
@@ -324,6 +326,8 @@ function useRxQuery<T>(
 				dispatch({
 					type: ActionType.FetchSuccess,
 					docs: json ? docs.map(doc => doc.toJSON()) : docs,
+					paginationMode,
+					pageSize,
 				});
 			}
 		);
@@ -331,15 +335,7 @@ function useRxQuery<T>(
 		return () => {
 			sub.unsubscribe();
 		};
-	}, [
-		query,
-		pageSize,
-		paginationMode,
-		sortBy,
-		sortOrder,
-		state.limit,
-		state.page,
-	]);
+	}, [query, pageSize, paginationMode, sortBy, sortOrder, state.page]);
 
 	useEffect(() => {
 		if (!state.page || !isRxQuery(query)) {

--- a/tests/helpers.tsx
+++ b/tests/helpers.tsx
@@ -53,6 +53,7 @@ interface CharacterListProps {
 	isFetching: boolean;
 	isExhausted: boolean;
 	pageCount?: number;
+	currentPage?: number;
 	resetList?: () => void;
 	fetchMore?: () => void;
 }
@@ -63,6 +64,7 @@ export const CharacterList: FC<CharacterListProps> = ({
 	isExhausted,
 	resetList,
 	pageCount,
+	currentPage,
 	fetchMore,
 }) => {
 	const handleReset = () => {
@@ -89,6 +91,7 @@ export const CharacterList: FC<CharacterListProps> = ({
 			<div>{isExhausted ? 'isExhausted' : null}</div>
 			<div>{isFetching ? 'loading' : null}</div>
 			<div>page count: {pageCount}</div>
+			<div>current page: {currentPage}</div>
 			<div>{characters.every(isRxDocument) ? 'RxDocument' : 'JSON'}</div>
 			<button onClick={handleReset}>reset</button>
 			<button onClick={handleMore}>more</button>

--- a/tests/useRxData.test.tsx
+++ b/tests/useRxData.test.tsx
@@ -159,6 +159,7 @@ describe('useRxData', () => {
 				result: characters,
 				isFetching,
 				isExhausted,
+				currentPage,
 				fetchMore,
 				resetList,
 			} = useRxData<Character>('characters', queryConstructor, {
@@ -170,6 +171,7 @@ describe('useRxData', () => {
 					characters={characters}
 					isFetching={isFetching}
 					isExhausted={isExhausted}
+					currentPage={currentPage}
 					fetchMore={fetchMore}
 					resetList={resetList}
 				/>
@@ -184,6 +186,8 @@ describe('useRxData', () => {
 
 		// should render in loading state
 		expect(screen.getByText('loading')).toBeInTheDocument();
+		// should start at 1st page
+		expect(screen.getByText('current page: 1')).toBeInTheDocument();
 
 		// wait for data
 		await waitForDomChange();
@@ -211,6 +215,8 @@ describe('useRxData', () => {
 
 		// should be loading
 		expect(screen.getByText('loading')).toBeInTheDocument();
+		// 2nd page should be the current page now
+		expect(screen.getByText('current page: 2')).toBeInTheDocument();
 
 		// wait for next page data to be rendered
 		await waitForDomChange();
@@ -231,6 +237,8 @@ describe('useRxData', () => {
 
 		// should be loading
 		expect(screen.getByText('loading')).toBeInTheDocument();
+		// 3rd page should be the current page now
+		expect(screen.getByText('current page: 3')).toBeInTheDocument();
 
 		// wait for last page data to be rendered
 		await waitForDomChange();

--- a/tests/useRxData.test.tsx
+++ b/tests/useRxData.test.tsx
@@ -260,6 +260,8 @@ describe('useRxData', () => {
 			})
 		);
 
+		expect(screen.getByText('current page: 1')).toBeInTheDocument();
+
 		await waitForDomChange();
 
 		// now only first page data should be rendered

--- a/tests/useRxData.test.tsx
+++ b/tests/useRxData.test.tsx
@@ -94,7 +94,7 @@ describe('useRxData', () => {
 			expect(screen.queryByText(doc.name)).toBeInTheDocument();
 		});
 
-		// should be isExhausted (no limit defined)
+		// should be exhausted (we fetched everything in one go)
 		expect(screen.getByText('isExhausted')).toBeInTheDocument();
 		// result should be an array of RxDocuments
 		expect(screen.getByText('RxDocument')).toBeInTheDocument();
@@ -330,6 +330,9 @@ describe('useRxData', () => {
 		// wait for data
 		await waitForDomChange();
 
+		// should not be in exhausted state
+		expect(screen.queryByText('isExhausted')).not.toBeInTheDocument();
+
 		// selected page data should now be rendered
 		bulkDocs.slice((startingPage - 1) * pageSize, pageSize).forEach(doc => {
 			expect(screen.getByText(doc.name)).toBeInTheDocument();
@@ -357,6 +360,9 @@ describe('useRxData', () => {
 		// should be loading
 		expect(screen.getByText('loading')).toBeInTheDocument();
 
+		// should not be in exhausted state
+		expect(screen.queryByText('isExhausted')).not.toBeInTheDocument();
+
 		// wait for previous page data to be rendered
 		await waitForDomChange();
 
@@ -371,6 +377,9 @@ describe('useRxData', () => {
 		].forEach(doc => {
 			expect(screen.queryByText(doc.name)).not.toBeInTheDocument();
 		});
+
+		// expect page count to be unaffected
+		expect(screen.getByText('page count: 3')).toBeInTheDocument();
 
 		done();
 	});


### PR DESCRIPTION
`currentPage` returned from `useRxQuery` & `useRxData`.

Relevant in "infinite scroll" pagination mode, useful in combination with `isFetching`