### PR TITLE
Properly reject wrong pages

### DIFF
--- a/src/useRxQuery.ts
+++ b/src/useRxQuery.ts
@@ -267,7 +267,7 @@ function useRxQuery<T>(
 			if (paginationMode !== PaginationMode.Traditional) {
 				return;
 			}
-			if (page < 0 || page > state.pageCount) {
+			if (page < 1 || page > state.pageCount) {
 				return;
 			}
 			dispatch({ type: ActionType.FetchPage, page });


### PR DESCRIPTION
Fixes issue with wrongly accepting out-of-bounds page numbers in traditional pagination mode, adds tests for this scenario and improves overall coverage.