### PR TITLE
Drop startPage & introduce new pagination option

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,14 +99,14 @@ function useRxQuery<T>(query: RxQuery, options?: UseRxQueryOptions): RxQueryResu
 | Option       | Type                         | Required |     Default     | Description                                                                                                                                    |
 | ------------ | ---------------------------- | :------: | :-------------: | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | `pageSize`   | `number`                     |    -     |        -        | enables pagination & defines page limit                                                                                                        |
-| `pagination` | `"Traditional" | "Infinite"` |    -     | `"Traditional"` | determines pagination mode                                                                                                                     |
+| `pagination` | `"Traditional" \| "Infinite"` |    -     | `"Traditional"` | determines pagination mode                                                                                                                     |
 | `json`       | `boolean`                    |    -     |     `false`     | when `true` resulting documents will be converted to plain JavaScript objects; equivalent to manually calling `.toJSON()` on each `RxDocument` |
 
 #### `result: RxQueryResult<T>`
 
 | Property      | Type                     | Description                                                                                                            |
 | ------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
-| `result`      | `T[] | RxDocument<T>[]`  | the resulting array of objects or `RxDocument` instances, depending on `json` option                                   |
+| `result`      | `T[] \| RxDocument<T>[]`  | the resulting array of objects or `RxDocument` instances, depending on `json` option                                   |
 | `isFetching`  | `boolean`                | fetching state indicator                                                                                               |
 | `currentPage` | `number`                 | relevant in **all** pagination modes; holds number of current page                                                     |
 | `isExhausted` | `boolean`                | relevant in **Infinite** pagination; flags result list as "exhausted", meaning all documents have been already fetched |

--- a/README.md
+++ b/README.md
@@ -96,21 +96,24 @@ function useRxQuery<T>(query: RxQuery, options?: UseRxQueryOptions): RxQueryResu
 
 #### `options: UseRxQueryOptions`
 
-| Option         | Type      | Required | Default | Description                                                                                                                                    |
-| -------------- | --------- | :------: | :-----: | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `pageSize`     | `number`  |    -     |   `0`   | enables pagination & defines page limit; `0` disables pagination and fetches everything                                                        |
-| `startingPage` | `number`  |    -     |    -    | 1-based number; enables tradional pagination mode & determines which page to fetch; works in combination with pageSize                         |
-| `json`         | `boolean` |    -     | `false` | when `true` resulting documents will be converted to plain JavaScript objects; equivalent to manually calling `.toJSON()` on each `RxDocument` |
+| Option       | Type                         | Required |     Default     | Description                                                                                                                                    |
+| ------------ | ---------------------------- | :------: | :-------------: | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pageSize`   | `number`                     |    -     |        -        | enables pagination & defines page limit                                                                                                        |
+| `pagination` | `"Traditional" | "Infinite"` |    -     | `"Traditional"` | determines pagination mode                                                                                                                     |
+| `json`       | `boolean`                    |    -     |     `false`     | when `true` resulting documents will be converted to plain JavaScript objects; equivalent to manually calling `.toJSON()` on each `RxDocument` |
 
 #### `result: RxQueryResult<T>`
 
-| Property      | Type                    | Description                                                                                                                             |
-| ------------- | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `result`      | `T[] \| RxDocument<T>[]` | the resulting array of objects or `RxDocument` instances, depending on `json` option                                                    |
-| `isFetching`  | `boolean`               | fetching state indicator                                                                                                                |
-| `isExhausted` | `boolean`               | flags result list as "isExhausted", meaning all documents have been already fetched; relevant when pagination is enabled via `pageSize` |
-| `fetchMore`   | `() => void`            | a function to be called by the consumer to request documents of the next page                                                           |
-| `resetList`   | `() => void`            | a function to be called by the consumer to reset paginated results                                                                      |
+| Property      | Type                     | Description                                                                                                            |
+| ------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| `result`      | `T[] | RxDocument<T>[]`  | the resulting array of objects or `RxDocument` instances, depending on `json` option                                   |
+| `isFetching`  | `boolean`                | fetching state indicator                                                                                               |
+| `currentPage` | `number`                 | relevant in **all** pagination modes; holds number of current page                                                     |
+| `isExhausted` | `boolean`                | relevant in **Infinite** pagination; flags result list as "exhausted", meaning all documents have been already fetched |
+| `fetchMore`   | `() => void`             | relevant in **Infinite** pagination; a function to be called by the consumer to request documents of the next page     |
+| `resetList`   | `() => void`             | relevant in **Infinite** pagination; a function to be called by the consumer to reset paginated results                |
+| `pageCount`   | `number`                 | relevant in **Traditional** pagination; holds the total number of pages available                                      |
+| `fetchPage`   | `(page: number) => void` | relevant in **Traditional** pagination; a function to be called by the consumer to request results of a specific page  |
 
 #### Simple Example
 
@@ -135,12 +138,13 @@ const query = collection
   .where('affiliation')
   .equals('Jedi');
 
-const {
-  result: characters,
-  isFetching,
-  fetchMore,
-  isExhausted,
-} = useRxQuery(query, { pageSize: 5 }); // fetch first page of 5 results
+const { result: characters, isFetching, fetchMore, isExhausted } = useRxQuery(
+  query,
+  {
+    pageSize: 5,
+    pagination: 'Infinite',
+  }
+);
 
 if (isFetching) {
   return 'Loading...';
@@ -166,15 +170,13 @@ const query = collection
   .where('affiliation')
   .equals('Jedi');
 
-const {
-  result: characters,
-  isFetching,
-  fetchPage,
-  pageCount, // holds total number of pages
-} = useRxQuery(query, {
-  pageSize: 5, // fetch 5 results per page
-  startingPage: 1, // start by showing the 1st page (1-based index)
-});
+const { result: characters, isFetching, fetchPage, pageCount } = useRxQuery(
+  query,
+  {
+    pageSize: 5,
+    pagination: 'Traditional',
+  }
+);
 
 if (isFetching) {
   return 'Loading...';
@@ -182,22 +184,26 @@ if (isFetching) {
 
 // render results and leverage pageCount to render page navigation
 return (
-  <CharacterList>
-    {characters.map((character, index) => (
-      <Character character={character} key={index} />
-    ))}
-    {Array(pageCount)
-      .fill()
-      .map((x, i) => (
-        <button
-          onClick={() => {
-            fetchPage(i + 1);
-          }}
-        >
-          page {i + 1}
-        </button>
+  <div>
+    <CharacterList>
+      {characters.map((character, index) => (
+        <Character character={character} key={index} />
       ))}
-  </CharacterList>
+    </CharacterList>
+    <div>
+      {Array(pageCount)
+        .fill()
+        .map((x, i) => (
+          <button
+            onClick={() => {
+              fetchPage(i + 1);
+            }}
+          >
+            page {i + 1}
+          </button>
+        ))}
+    </div>
+  </div>
 );
 ```
 

--- a/tests/useRxData.test.tsx
+++ b/tests/useRxData.test.tsx
@@ -377,7 +377,7 @@ describe('useRxData', () => {
 				resetList,
 			} = useRxData<Character>('characters', queryConstructor, {
 				pageSize,
-				pagination: PaginationMode.Traditional,
+				pagination: 'Traditional',
 			});
 
 			return (

--- a/tests/useRxData.test.tsx
+++ b/tests/useRxData.test.tsx
@@ -16,6 +16,7 @@ import {
 import { RxDatabase, RxCollection } from 'rxdb';
 import useRxData from '../src/useRxData';
 import Provider from '../src/Provider';
+import { PaginationMode } from '../src/useRxQuery';
 
 describe('useRxData', () => {
 	let db: RxDatabase;
@@ -358,7 +359,6 @@ describe('useRxData', () => {
 	});
 
 	it('should support traditional pagination', async done => {
-		const startingPage = 2;
 		const pageSize = 2;
 
 		const Child: FC = () => {
@@ -371,22 +371,23 @@ describe('useRxData', () => {
 				isFetching,
 				isExhausted,
 				pageCount,
+				currentPage,
 				fetchPage,
 				fetchMore,
 				resetList,
 			} = useRxData<Character>('characters', queryConstructor, {
 				pageSize,
-				startingPage,
+				pagination: PaginationMode.Traditional,
 			});
 
 			return (
 				<>
 					<button
 						onClick={() => {
-							fetchPage(startingPage - 1);
+							fetchPage(currentPage + 1);
 						}}
 					>
-						previous page
+						next page
 					</button>
 					<button
 						onClick={() => {
@@ -416,21 +417,19 @@ describe('useRxData', () => {
 		// should render in loading state
 		expect(screen.getByText('loading')).toBeInTheDocument();
 
-		// wait for data
+		// wait for data (twice since pages are also counted)
+		await waitForDomChange();
 		await waitForDomChange();
 
 		// should not be in exhausted state
 		expect(screen.queryByText('isExhausted')).not.toBeInTheDocument();
 
 		// selected page data should now be rendered
-		bulkDocs.slice((startingPage - 1) * pageSize, pageSize).forEach(doc => {
+		bulkDocs.slice(0, pageSize).forEach(doc => {
 			expect(screen.getByText(doc.name)).toBeInTheDocument();
 		});
 		// rest data should not be rendered
-		[
-			...bulkDocs.slice(0, (startingPage - 1) * pageSize),
-			...bulkDocs.slice((startingPage - 1) * pageSize + pageSize),
-		].forEach(doc => {
+		bulkDocs.slice(pageSize).forEach(doc => {
 			expect(screen.queryByText(doc.name)).not.toBeInTheDocument();
 		});
 
@@ -439,7 +438,7 @@ describe('useRxData', () => {
 
 		// trigger fetching of previous page
 		fireEvent(
-			screen.getByText('previous page'),
+			screen.getByText('next page'),
 			new MouseEvent('click', {
 				bubbles: true,
 				cancelable: true,
@@ -452,17 +451,17 @@ describe('useRxData', () => {
 		// should not be in exhausted state
 		expect(screen.queryByText('isExhausted')).not.toBeInTheDocument();
 
-		// wait for previous page data to be rendered
+		// wait for next page data to be rendered
 		await waitForDomChange();
 
-		// previous page data should now be rendered
-		bulkDocs.slice((startingPage - 2) * pageSize, pageSize).forEach(doc => {
+		// next page data should now be rendered
+		bulkDocs.slice(pageSize, pageSize).forEach(doc => {
 			expect(screen.getByText(doc.name)).toBeInTheDocument();
 		});
 		// rest data should not be rendered
 		[
-			...bulkDocs.slice(0, (startingPage - 2) * pageSize),
-			...bulkDocs.slice((startingPage - 2) * pageSize + pageSize),
+			...bulkDocs.slice(0, pageSize),
+			...bulkDocs.slice(2 * pageSize),
 		].forEach(doc => {
 			expect(screen.queryByText(doc.name)).not.toBeInTheDocument();
 		});
@@ -482,13 +481,13 @@ describe('useRxData', () => {
 		// should be a noop since we requested a page that doesn't does not exist:
 		// should not be loading
 		expect(screen.queryByText('loading')).not.toBeInTheDocument();
-		// same data should still be rendered
-		bulkDocs.slice((startingPage - 2) * pageSize, pageSize).forEach(doc => {
+		// same data should now be rendered
+		bulkDocs.slice(pageSize, pageSize).forEach(doc => {
 			expect(screen.getByText(doc.name)).toBeInTheDocument();
 		});
 		[
-			...bulkDocs.slice(0, (startingPage - 2) * pageSize),
-			...bulkDocs.slice((startingPage - 2) * pageSize + pageSize),
+			...bulkDocs.slice(0, pageSize),
+			...bulkDocs.slice(2 * pageSize),
 		].forEach(doc => {
 			expect(screen.queryByText(doc.name)).not.toBeInTheDocument();
 		});


### PR DESCRIPTION
* drop `startPage` option (traditional pagination always starts from 1st page) 
* pagination mode is now explicitly set by the new `pagination` option (defaults to `"Infinite"`)