### PR TITLE
Properly handle empty findOne() query results

### DIFF
--- a/src/useRxDocument.ts
+++ b/src/useRxDocument.ts
@@ -54,7 +54,7 @@ function useRxDocument<T>(
 		(c: RxCollection<T>) =>
 			id
 				? c
-						.find()
+						.findOne()
 						.where(preferredIdAttribute)
 						.equals(id)
 				: undefined,

--- a/src/useRxQuery.ts
+++ b/src/useRxQuery.ts
@@ -188,8 +188,17 @@ const reducer = <T>(state: RxState<T>, action: AnyAction<T>): RxState<T> => {
 	}
 };
 
-const getResultArray = <T>(documents: RxDocument<T>[] | RxDocument<T>) =>
-	Array.isArray(documents) ? documents : [documents];
+const getResultArray = <T>(
+	result: RxDocument<T>[] | RxDocument<T> | null
+): RxDocument<T>[] => {
+	if (!result) {
+		return [];
+	}
+	if (Array.isArray(result)) {
+		return result;
+	}
+	return [result];
+};
 
 function useRxQuery<T>(query: RxQuery): RxQueryResultDoc<T>;
 
@@ -281,8 +290,8 @@ function useRxQuery<T>(
 		});
 
 		const sub = _query.$.subscribe(
-			(documents: RxDocument<T>[] | RxDocument<T>) => {
-				const docs = getResultArray(documents);
+			(result: RxDocument<T>[] | RxDocument<T> | null) => {
+				const docs = getResultArray(result);
 				dispatch({
 					type: ActionType.FetchSuccess,
 					docs: json ? docs.map(doc => doc.toJSON()) : docs,
@@ -304,8 +313,8 @@ function useRxQuery<T>(
 		// Unconvential counting of documents/pages due to missing RxQuery.count():
 		// https://github.com/pubkey/rxdb/blob/master/orga/BACKLOG.md#rxquerycount
 		const countQuerySub = query.$.subscribe(
-			(documents: RxDocument<T>[] | RxDocument<T>) => {
-				const docs = getResultArray(documents);
+			(result: RxDocument<T>[] | RxDocument<T> | null) => {
+				const docs = getResultArray(result);
 				dispatch({
 					type: ActionType.CountPages,
 					pageCount: Math.ceil(docs.length / pageSize),

--- a/tests/useRxDocument.test.tsx
+++ b/tests/useRxDocument.test.tsx
@@ -186,6 +186,35 @@ describe('useRxDocument', () => {
 		done();
 	});
 
+	it('should handle not found', async done => {
+		const Child: FC = () => {
+			const { result: character, isFetching } = useRxDocument<Character>(
+				'characters',
+				'Mace Windu',
+				{ idAttribute: 'name' }
+			);
+
+			return <Character character={character} isFetching={isFetching} />;
+		};
+
+		render(
+			<Provider db={db}>
+				<Child />
+			</Provider>
+		);
+
+		// should render in loading state
+		expect(screen.getByText('loading')).toBeInTheDocument();
+
+		// wait for data
+		await waitForDomChange();
+
+		expect(screen.queryByText('loading')).not.toBeInTheDocument();
+		expect(screen.queryByText('Mace Windu')).not.toBeInTheDocument();
+
+		done();
+	});
+
 	it('should allow numeric id attributes', async done => {
 		const Child: FC = () => {
 			const { result: character, isFetching } = useRxDocument<Character>(


### PR DESCRIPTION
* Translate null query results to empty array (i.e. on `findOne()` queries)
* `useRxDocument` internally uses `findOne()`