### PR TITLE
Type improvements

### DIFF
--- a/src/type.helpers.ts
+++ b/src/type.helpers.ts
@@ -1,0 +1,1 @@
+export type Override<T, R> = Omit<T, keyof R> & R;

--- a/src/useRxData.ts
+++ b/src/useRxData.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { RxCollection, RxQuery, RxDocument } from 'rxdb';
+import { Override } from './type.helpers';
 import useRxCollection from './useRxCollection';
 import useRxQuery, {
 	UseRxQueryOptions,
@@ -20,13 +21,13 @@ function useRxData<T>(
 function useRxData<T>(
 	collectionName: string,
 	queryConstructor: QueryConstructor<T> | undefined,
-	options?: UseRxQueryOptions & { json?: false }
+	options?: Override<UseRxQueryOptions, { json?: false }>
 ): RxQueryResultDoc<T>;
 
 function useRxData<T>(
 	collectionName: string,
 	queryConstructor: QueryConstructor<T> | undefined,
-	options?: UseRxQueryOptions & { json: true }
+	options?: Override<UseRxQueryOptions, { json: true }>
 ): RxQueryResultJSON<T>;
 
 /**

--- a/src/useRxData.ts
+++ b/src/useRxData.ts
@@ -10,7 +10,7 @@ import useRxQuery, {
 
 export type QueryConstructor<T> = (
 	collection: RxCollection<T>
-) => RxQuery<T, RxDocument<T> | RxDocument<T>[]> | undefined;
+) => RxQuery<T, RxDocument<T>> | RxQuery<T, RxDocument<T>[]> | undefined;
 
 function useRxData<T>(
 	collectionName: string,

--- a/src/useRxDocument.ts
+++ b/src/useRxDocument.ts
@@ -1,5 +1,5 @@
 import { useCallback, useContext } from 'react';
-import useData from './useRxData';
+import useRxData from './useRxData';
 import { RxCollection, RxDocument } from 'rxdb';
 import Context from './context';
 import { Override } from './type.helpers';
@@ -66,9 +66,9 @@ function useRxDocument<T>(
 	// TODO: find a better workaround
 	const { result, isFetching } = json
 		? // eslint-disable-next-line react-hooks/rules-of-hooks
-		  useData<T>(collectionName, queryConstructor, { json: true })
+		  useRxData<T>(collectionName, queryConstructor, { json: true })
 		: // eslint-disable-next-line react-hooks/rules-of-hooks
-		  useData<T>(collectionName, queryConstructor, { json: false });
+		  useRxData<T>(collectionName, queryConstructor, { json: false });
 
 	return { result: result[0], isFetching };
 }

--- a/src/useRxDocument.ts
+++ b/src/useRxDocument.ts
@@ -2,6 +2,7 @@ import { useCallback, useContext } from 'react';
 import useData from './useRxData';
 import { RxCollection, RxDocument } from 'rxdb';
 import Context from './context';
+import { Override } from './type.helpers';
 
 export interface RxDocumentRet<T> {
 	result?: T | RxDocument<T>;
@@ -24,13 +25,13 @@ export interface UseRxDocumentOptions {
 function useRxDocument<T>(
 	collectionName: string,
 	id?: string | number,
-	options?: UseRxDocumentOptions & { json: true }
+	options?: Override<UseRxDocumentOptions, { json: true }>
 ): RxDocumentJSON<T>;
 
 function useRxDocument<T>(
 	collectionName: string,
 	id?: string | number,
-	options?: UseRxDocumentOptions & { json?: false }
+	options?: Override<UseRxDocumentOptions, { json?: false }>
 ): RxDocumentDoc<T>;
 
 /**

--- a/src/useRxQuery.ts
+++ b/src/useRxQuery.ts
@@ -1,5 +1,6 @@
 import { useEffect, useCallback, useReducer, Reducer } from 'react';
 import { RxQuery, RxDocument, isRxQuery } from 'rxdb';
+import { Override } from './type.helpers';
 
 export interface RxQueryResult<T> {
 	/**
@@ -204,12 +205,12 @@ function useRxQuery<T>(query: RxQuery): RxQueryResultDoc<T>;
 
 function useRxQuery<T>(
 	query: RxQuery,
-	options?: UseRxQueryOptions & { json?: false }
+	options?: Override<UseRxQueryOptions, { json?: false }>
 ): RxQueryResultDoc<T>;
 
 function useRxQuery<T>(
 	query: RxQuery,
-	options?: UseRxQueryOptions & { json: true }
+	options?: Override<UseRxQueryOptions, { json: true }>
 ): RxQueryResultJSON<T>;
 
 /**

--- a/tests/useRxData.test.tsx
+++ b/tests/useRxData.test.tsx
@@ -27,7 +27,7 @@ describe('useRxData', () => {
 	it('should read all data from a collection', async done => {
 		const Child: FC = () => {
 			const queryConstructor = useCallback(
-				(c: RxCollection) => c.find(),
+				(c: RxCollection<Character>) => c.find(),
 				[]
 			);
 			const {
@@ -114,7 +114,7 @@ describe('useRxData', () => {
 	it('should return data in JSON format', async done => {
 		const Child: FC = () => {
 			const queryConstructor = useCallback(
-				(c: RxCollection) => c.find(),
+				(c: RxCollection<Character>) => c.find(),
 				[]
 			);
 			const { result: characters, isFetching, isExhausted } = useRxData<
@@ -161,7 +161,7 @@ describe('useRxData', () => {
 
 		const Child: FC = () => {
 			const queryConstructor = useCallback(
-				(c: RxCollection) => c.find(),
+				(c: RxCollection<Character>) => c.find(),
 				[]
 			);
 			const {
@@ -329,7 +329,7 @@ describe('useRxData', () => {
 
 		const Child: FC = () => {
 			const queryConstructor = useCallback(
-				(c: RxCollection) => c.find(),
+				(c: RxCollection<Character>) => c.find(),
 				[]
 			);
 			const {
@@ -479,7 +479,7 @@ describe('useRxData', () => {
 		const idToSearchFor = '1';
 		const Child: FC = () => {
 			const queryConstructor = useCallback(
-				(c: RxCollection) =>
+				(c: RxCollection<Character>) =>
 					c
 						.findOne()
 						.where('id')
@@ -559,7 +559,7 @@ describe('useRxData', () => {
 	it('should handle missing collection', async done => {
 		const Child: FC = () => {
 			const queryConstructor = useCallback(
-				(c: RxCollection) => c.find(),
+				(c: RxCollection<Character>) => c.find(),
 				[]
 			);
 			const {
@@ -597,7 +597,7 @@ describe('useRxData', () => {
 	it('should handle missing database', async done => {
 		const Child: FC = () => {
 			const queryConstructor = useCallback(
-				(c: RxCollection) => c.find(),
+				(c: RxCollection<Character>) => c.find(),
 				[]
 			);
 			const {
@@ -636,7 +636,7 @@ describe('useRxData', () => {
 		const Child: FC = () => {
 			const [name, setName] = useState('');
 			const queryConstructor = useCallback(
-				(c: RxCollection) => {
+				(c: RxCollection<Character>) => {
 					if (name) {
 						return c
 							.find()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
 	  "outDir": "dist",
 	  "declaration": true
 	},
-	"include": ["src"],
+	"include": ["src", "tests"],
 	"exclude": [
 	  "node_modules"
 	]


### PR DESCRIPTION
* Improve `QueryConstructor` typings for `useRxData`
* Properly override options across all function overloads
* Include **/test** in typechecks 