### PR TITLE
Support lazy collection initialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 	"scripts": {
 		"prettier": "prettier --write \"src/**/*.{js,ts,jsx,tsx}\"",
 		"lint": "eslint \"src/**/*.{js,ts,jsx,tsx}\" --ignore-path .gitignore",
-		"test": "yarn jest --no-cache --forceExit",
+		"test": "yarn jest --no-cache --forceExit --runInBand",
 		"build": "rimraf dist && tsc --project tsconfig.json",
 		"prepack": "yarn build",
 		"typecheck": "tsc --noEmit",
@@ -52,7 +52,8 @@
 	"peerDependencies": {
 		"react": ">=16.8",
 		"react-dom": ">=16.8",
-		"rxdb": ">=8.7"
+		"rxdb": ">=9",
+		"rxjs": ">=6"
 	},
 	"resolutions": {
 		"minimist": "1.2.5"

--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -1,6 +1,7 @@
-import React, { FC, useMemo } from 'react';
-import { RxDatabase } from 'rxdb';
+import React, { FC, useMemo, useEffect } from 'react';
+import { RxDatabase, addRxPlugin } from 'rxdb';
 import Context from './context';
+import { newCollectionObserver } from './plugins';
 
 export interface ProviderProps {
 	db?: RxDatabase;
@@ -8,6 +9,9 @@ export interface ProviderProps {
 }
 
 const Provider: FC<ProviderProps> = ({ db, idAttribute = '_id', children }) => {
+	useEffect(() => {
+		addRxPlugin(newCollectionObserver);
+	}, []);
 	const context = useMemo(
 		() => ({
 			db,

--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useMemo, useEffect } from 'react';
 import { RxDatabase, addRxPlugin } from 'rxdb';
 import Context from './context';
-import { observeNewCollections } from './plugins';
+import { observeNewCollections, RxDatabaseBaseExtended } from './plugins';
 
 export interface ProviderProps {
 	db?: RxDatabase;
@@ -14,7 +14,7 @@ const Provider: FC<ProviderProps> = ({ db, idAttribute = '_id', children }) => {
 	}, []);
 	const context = useMemo(
 		() => ({
-			db,
+			db: (db as unknown) as RxDatabaseBaseExtended,
 			idAttribute,
 		}),
 		[db, idAttribute]

--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useMemo, useEffect } from 'react';
 import { RxDatabase, addRxPlugin } from 'rxdb';
 import Context from './context';
-import { newCollectionObserver } from './plugins';
+import { observeNewCollections } from './plugins';
 
 export interface ProviderProps {
 	db?: RxDatabase;
@@ -10,7 +10,7 @@ export interface ProviderProps {
 
 const Provider: FC<ProviderProps> = ({ db, idAttribute = '_id', children }) => {
 	useEffect(() => {
-		addRxPlugin(newCollectionObserver);
+		addRxPlugin(observeNewCollections);
 	}, []);
 	const context = useMemo(
 		() => ({

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,8 +1,8 @@
 import { createContext } from 'react';
-import { RxDatabase } from 'rxdb';
+import { RxDatabaseBaseExtended } from './plugins';
 
 export interface RxContext {
-	db: RxDatabase | null;
+	db: RxDatabaseBaseExtended | null;
 	idAttribute: string;
 }
 

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -4,20 +4,24 @@ import { RxDatabaseBase } from 'rxdb/dist/types/rx-database';
 
 type CollectionRecord = Record<string, RxCollection>;
 export type RxDatabaseBaseExtended = RxDatabaseBase & {
-	collections$: Subject<CollectionRecord>;
+	newCollections$: Subject<CollectionRecord>;
 };
 
-export const newCollectionObserver = {
+/**
+ * Extends RxDB prototype with a newCollections$ property: a stream emitting any
+ * new collections added via addCollections().
+ */
+export const observeNewCollections = {
 	rxdb: true,
 	prototypes: {
 		RxDatabase: (proto: RxDatabaseBaseExtended) => {
-			const collections$ = new Subject<CollectionRecord>();
-			proto.collections$ = collections$;
+			const newCollections$ = new Subject<CollectionRecord>();
+			proto.newCollections$ = newCollections$;
 
 			const orig = proto.addCollections;
 			proto.addCollections = async function(...args) {
 				const col = await orig.apply(this, args);
-				collections$.next(col);
+				newCollections$.next(col);
 				return col;
 			};
 		},

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -1,0 +1,25 @@
+import { Subject } from 'rxjs';
+import { RxCollection } from 'rxdb';
+import { RxDatabaseBase } from 'rxdb/dist/types/rx-database';
+
+type CollectionRecord = Record<string, RxCollection>;
+export type RxDatabaseBaseExtended = RxDatabaseBase & {
+	collections$: Subject<CollectionRecord>;
+};
+
+export const newCollectionObserver = {
+	rxdb: true,
+	prototypes: {
+		RxDatabase: (proto: RxDatabaseBaseExtended) => {
+			const collections$ = new Subject<CollectionRecord>();
+			proto.collections$ = collections$;
+
+			const orig = proto.addCollections;
+			proto.addCollections = async function(...args) {
+				const col = await orig.apply(this, args);
+				collections$.next(col);
+				return col;
+			};
+		},
+	},
+};

--- a/src/useRxCollection.ts
+++ b/src/useRxCollection.ts
@@ -14,7 +14,7 @@ function useRxCollection<T>(name: string): RxCollection<T> | null {
 		if (found) {
 			setCollection(found);
 		} else {
-			const sub = db.collections$.subscribe(col => {
+			const sub = db.newCollections$.subscribe(col => {
 				if (col[name]) {
 					setCollection(col[name]);
 					sub.unsubscribe();

--- a/src/useRxCollection.ts
+++ b/src/useRxCollection.ts
@@ -13,6 +13,18 @@ function useRxCollection<T>(name: string): RxCollection<T> | null {
 		const found = db[name];
 		if (found) {
 			setCollection(found);
+		} else {
+			const sub = db.collections$.subscribe(col => {
+				if (col[name]) {
+					setCollection(col[name]);
+					sub.unsubscribe();
+				}
+			});
+			return () => {
+				if (!sub.closed) {
+					sub.unsubscribe();
+				}
+			};
 		}
 	}, [db, name]);
 

--- a/src/useRxDB.ts
+++ b/src/useRxDB.ts
@@ -1,8 +1,8 @@
 import { useContext } from 'react';
-import { RxDatabase } from 'rxdb';
 import Context from './context';
+import { RxDatabaseBaseExtended } from './plugins';
 
-function useRxDB(): RxDatabase {
+function useRxDB(): RxDatabaseBaseExtended {
 	const { db } = useContext(Context);
 	return db;
 }

--- a/tests/helpers.tsx
+++ b/tests/helpers.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import RxDB, { RxDatabase, isRxDocument } from 'rxdb';
+import RxDB, { RxDatabase, isRxDocument, RxCollection } from 'rxdb';
 import memoryAdapter from 'pouchdb-adapter-memory';
 
 RxDB.plugin(memoryAdapter);
@@ -9,14 +9,19 @@ export interface Character {
 	affiliation: string;
 }
 
-export const setup = async (
-	documents: Character[],
-	collectionName = 'test_collection'
-): Promise<RxDatabase> => {
+export const createDatabase = async (): Promise<RxDatabase> => {
 	const db = await RxDB.create({
 		name: 'test_database',
 		adapter: 'memory',
 	});
+	return db;
+};
+
+export const setupCollection = async (
+	db: RxDatabase,
+	documents: Character[],
+	collectionName = 'test_collection'
+): Promise<RxCollection> => {
 	const collection = await db.collection({
 		name: collectionName,
 		schema: {
@@ -42,6 +47,15 @@ export const setup = async (
 		},
 	});
 	await collection.bulkInsert(documents);
+	return collection;
+};
+
+export const setup = async (
+	documents: Character[],
+	collectionName = 'test_collection'
+): Promise<RxDatabase> => {
+	const db = await createDatabase();
+	await setupCollection(db, documents, collectionName);
 	return db;
 };
 

--- a/tests/helpers.tsx
+++ b/tests/helpers.tsx
@@ -20,6 +20,7 @@ export const createDatabase = async (): Promise<RxDatabase> => {
 	const db = await createRxDatabase({
 		name: 'test_database',
 		adapter: 'memory',
+		ignoreDuplicate: true,
 	});
 	return db;
 };

--- a/tests/useRxData.test.tsx
+++ b/tests/useRxData.test.tsx
@@ -776,7 +776,12 @@ describe('useRxData + lazy collection init', () => {
 		// should render in loading state
 		expect(screen.getByText('loading')).toBeInTheDocument();
 
-		// lazily create collection
+		// lazily create a collection we don't care about
+		await act(async () => {
+			await setupCollection(db, [], 'other');
+		});
+
+		// lazily create the collection we'be been waiting for
 		await act(async () => {
 			await setupCollection(db, characters, 'characters');
 		});
@@ -784,7 +789,10 @@ describe('useRxData + lazy collection init', () => {
 		// wait for data
 		await waitForDomChange();
 
-		// TODO: verify results exist in the dom
+		// data should now be rendered
+		characters.forEach(doc => {
+			expect(screen.queryByText(doc.name)).toBeInTheDocument();
+		});
 
 		done();
 	});

--- a/tests/useRxData.test.tsx
+++ b/tests/useRxData.test.tsx
@@ -17,6 +17,7 @@ import { RxDatabase, RxCollection } from 'rxdb';
 import useRxData from '../src/useRxData';
 import Provider from '../src/Provider';
 import { characters } from './mockData';
+import { act } from 'react-dom/test-utils';
 
 describe('useRxData', () => {
 	let db: RxDatabase;
@@ -776,10 +777,14 @@ describe('useRxData + lazy collection init', () => {
 		expect(screen.getByText('loading')).toBeInTheDocument();
 
 		// lazily create collection
-		await setupCollection(db, characters, 'characters');
+		await act(async () => {
+			await setupCollection(db, characters, 'characters');
+		});
 
-		// wait for data - this will timeout
+		// wait for data
 		await waitForDomChange();
+
+		// TODO: verify results exist in the dom
 
 		done();
 	});


### PR DESCRIPTION
The aim of this is to allow collections to be lazily created after the db instance has been initially passed to the provider, as described in #27.

- [x] add test case for lazily collection init
- [x] pick up newly created collections in `useRxCollection`