### PR TITLE
Support findByIds() query

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,39 @@
+/**
+ * Second variable in array is a function that can be invoked to cancel the promise.
+ */
+export type CancelablePromise<T> = [Promise<T>, () => void];
+
+/**
+ * Makes promise cancelable.
+ * Wraps original promise in an object that exposes said promise
+ * and also exposes a cancel() method for canceling the promise.
+ * Canceling the promise will prevent it from resolving/rejecting once the
+ * the underlying promise resolves/reject.
+ */
+export const getCancelablePromise = <T>(
+	promise: Promise<T>
+): CancelablePromise<T> => {
+	let hasCanceled = false;
+
+	const wrappedPromise = new Promise<T>((resolve, reject) => {
+		promise.then(
+			(val: T) => {
+				if (!hasCanceled) {
+					resolve(val);
+				}
+			},
+			(error: any) => {
+				if (!hasCanceled) {
+					reject(error);
+				}
+			}
+		);
+	});
+
+	return [
+		wrappedPromise,
+		() => {
+			hasCanceled = true;
+		},
+	];
+};

--- a/src/useRxData.ts
+++ b/src/useRxData.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { RxCollection, RxQuery, RxDocument } from 'rxdb';
+import { RxCollection } from 'rxdb';
 import { Override } from './type.helpers';
 import useRxCollection from './useRxCollection';
 import useRxQuery, {
@@ -7,11 +7,12 @@ import useRxQuery, {
 	RxQueryResult,
 	RxQueryResultJSON,
 	RxQueryResultDoc,
+	AnyRxQuery,
 } from './useRxQuery';
 
 export type QueryConstructor<T> = (
 	collection: RxCollection<T>
-) => RxQuery<T, RxDocument<T>> | RxQuery<T, RxDocument<T>[]> | undefined;
+) => AnyRxQuery<T> | undefined;
 
 function useRxData<T>(
 	collectionName: string,

--- a/src/useRxQuery.ts
+++ b/src/useRxQuery.ts
@@ -326,18 +326,19 @@ function useRxQuery<T>(
 			dispatch({
 				type: ActionType.QueryChanged,
 			});
-			// TODO: re-enable TS and fix type error
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore
-			const sub = _query.$.subscribe((result) => {
-				const docs = getResultArray(result, json);
-				dispatch({
-					type: ActionType.FetchSuccess,
-					docs,
-					pagination,
-					pageSize,
-				});
-			});
+			// TODO: find more elegant way to resolve type error
+			// (TS doesn't consider _query.$.subscribe to be callable)
+			const sub = (_query.$.subscribe as any)(
+				(result: RxDocument<T> | RxDocument<T>[]) => {
+					const docs = getResultArray(result, json);
+					dispatch({
+						type: ActionType.FetchSuccess,
+						docs,
+						pagination,
+						pageSize,
+					});
+				}
+			);
 
 			return () => {
 				sub.unsubscribe();
@@ -390,16 +391,17 @@ function useRxQuery<T>(
 		if (isRxQuery(query)) {
 			// Unconvential counting of documents/pages due to missing RxQuery.count():
 			// https://github.com/pubkey/rxdb/blob/master/orga/BACKLOG.md#rxquerycount
-			// TODO: re-enable TS and fix type error
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore
-			const countQuerySub = query.$.subscribe((result) => {
-				const resultLength = getResultLength(result);
-				dispatch({
-					type: ActionType.CountPages,
-					pageCount: Math.ceil(resultLength / pageSize),
-				});
-			});
+			// TODO: find more elegant way to resolve type error
+			// (TS doesn't consider _query.$.subscribe to be callable)
+			const countQuerySub = (query.$.subscribe as any)(
+				(result: RxDocument<T> | RxDocument<T>[]) => {
+					const resultLength = getResultLength(result);
+					dispatch({
+						type: ActionType.CountPages,
+						pageCount: Math.ceil(resultLength / pageSize),
+					});
+				}
+			);
 
 			return () => {
 				countQuerySub.unsubscribe();

--- a/src/useRxQuery.ts
+++ b/src/useRxQuery.ts
@@ -226,13 +226,10 @@ const getResultArray = <T>(
 };
 
 const getResultLength = <T>(
-	result: RxDocument<T>[] | RxDocument<T> | ResultMap<T> | null
+	result: RxDocument<T>[] | RxDocument<T> | null
 ): number => {
 	if (!result) {
 		return 0;
-	}
-	if (result instanceof Map) {
-		return result.size;
 	}
 	const resultArray = Array.isArray(result) ? result : [result];
 	return resultArray.length;
@@ -381,11 +378,12 @@ function useRxQuery<T>(
 	}, [query, performPromiseReturningQuery, performObservableReturningQuery]);
 
 	useEffect(() => {
-		if (!query || !pageSize || pagination !== 'Traditional') {
-			return;
-		}
-		if ('then' in query) {
-			// TODO: does pagination make sense when using findByIds()?
+		if (
+			!query ||
+			!pageSize ||
+			pagination !== 'Traditional' ||
+			'then' in query
+		) {
 			return;
 		}
 		if (isRxQuery(query)) {

--- a/src/useRxQuery.ts
+++ b/src/useRxQuery.ts
@@ -88,6 +88,17 @@ export interface UseRxQueryOptions {
 	json?: boolean;
 }
 
+/**
+ * Most query functions on RxCollection return RxQuery objects with
+ * BehaviorSubject instances ($) attached to them except for .findByIds()
+ * which returns a promise.
+ */
+export type ObservableReturningQuery<T> =
+	| RxQuery<T, RxDocument<T>>
+	| RxQuery<T, RxDocument<T>[]>;
+export type PromiseReturning<T> = Promise<Map<string, RxDocument<T, any>>>;
+export type AnyRxQuery<T> = ObservableReturningQuery<T> | PromiseReturning<T>;
+
 interface RxState<T> {
 	result: DeepReadonly<T>[] | RxDocument<T>[];
 	isFetching: boolean;
@@ -202,15 +213,15 @@ const getResultArray = <T>(
 	return [result];
 };
 
-function useRxQuery<T>(query: RxQuery): RxQueryResultDoc<T>;
+function useRxQuery<T>(query: AnyRxQuery<T>): RxQueryResultDoc<T>;
 
 function useRxQuery<T>(
-	query: RxQuery,
+	query: AnyRxQuery<T>,
 	options?: Override<UseRxQueryOptions, { json?: false }>
 ): RxQueryResultDoc<T>;
 
 function useRxQuery<T>(
-	query: RxQuery,
+	query: AnyRxQuery<T>,
 	options?: Override<UseRxQueryOptions, { json: true }>
 ): RxQueryResultJSON<T>;
 
@@ -221,7 +232,7 @@ function useRxQuery<T>(
  *  - a resetList callback function for conveniently reseting list data
  */
 function useRxQuery<T>(
-	query: RxQuery<RxDocument<T>>,
+	query: AnyRxQuery<T>,
 	options: UseRxQueryOptions = {}
 ): RxQueryResult<T> {
 	const { pageSize, pagination = 'Infinite', json } = options;

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -1,0 +1,50 @@
+import { delay } from './helpers';
+import { getCancelablePromise } from '../src/helpers';
+
+describe('getCancelablePromise()', () => {
+	it('should allow uncancelled promises to resolve', () => {
+		const promise = new Promise<string>((resolve) => {
+			setTimeout(() => {
+				resolve('Voila');
+			}, 10);
+		});
+		const [cancelable] = getCancelablePromise(promise);
+		return expect(cancelable).resolves.toBe('Voila');
+	});
+
+	it('should allow uncancelled promises to reject', () => {
+		const promise = new Promise((resolve, reject) => {
+			setTimeout(() => {
+				reject('Boom');
+			}, 10);
+		});
+		const [cancelable] = getCancelablePromise(promise);
+		return expect(cancelable).rejects.toBe('Boom');
+	});
+
+	it('should allow cancelling resolving promises', async () => {
+		const promise = new Promise<string>((resolve) => {
+			setTimeout(() => {
+				resolve('Voila');
+			}, 10);
+		});
+		const [cancelable, cancel] = getCancelablePromise(promise);
+		const spy = jest.fn();
+		cancelable.then(spy);
+		cancel();
+		await delay(15);
+		expect(spy.mock.calls.length).toBe(0);
+	});
+
+	it('should allow cancelling rejecting promises', async () => {
+		const promise = new Promise((resolve, reject) => {
+			setTimeout(reject, 10);
+		});
+		const [cancelable, cancel] = getCancelablePromise(promise);
+		const spy = jest.fn();
+		cancelable.catch(spy);
+		cancel();
+		await delay(15);
+		expect(spy.mock.calls.length).toBe(0);
+	});
+});

--- a/tests/useRxData.test.tsx
+++ b/tests/useRxData.test.tsx
@@ -132,7 +132,9 @@ describe('useRxData', () => {
 				isFetching,
 				isExhausted,
 				resetList,
-			} = useRxData<Character>('characters', queryConstructor);
+			} = useRxData<Character>('characters', queryConstructor, {
+				json: true,
+			});
 
 			return (
 				<>
@@ -168,7 +170,7 @@ describe('useRxData', () => {
 					).not.toBeInTheDocument();
 				}
 			});
-			expect(screen.getByText('loading')).not.toBeInTheDocument();
+			expect(screen.queryByText('loading')).not.toBeInTheDocument();
 		});
 	});
 

--- a/tests/useRxData.test.tsx
+++ b/tests/useRxData.test.tsx
@@ -19,17 +19,17 @@ import { act } from 'react-dom/test-utils';
 describe('useRxData', () => {
 	let db: MyDatabase;
 
-	beforeAll(async done => {
+	beforeAll(async (done) => {
 		db = await setup(characters, 'characters');
 		done();
 	});
 
-	afterAll(async done => {
+	afterAll(async (done) => {
 		await teardown(db);
 		done();
 	});
 
-	it('should read all data from a collection', async done => {
+	it('should read all data from a collection', async (done) => {
 		const Child: FC = () => {
 			const queryConstructor = useCallback(
 				(c: RxCollection<Character>) => c.find(),
@@ -75,7 +75,7 @@ describe('useRxData', () => {
 		// wait for data
 		await waitFor(async () => {
 			// data should now be rendered
-			characters.forEach(doc => {
+			characters.forEach((doc) => {
 				expect(screen.queryByText(doc.name)).toBeInTheDocument();
 			});
 
@@ -113,22 +113,78 @@ describe('useRxData', () => {
 		// noop: not in traditional pagination
 		expect(screen.queryByText('loading')).not.toBeInTheDocument();
 		// data should still be rendered
-		characters.forEach(doc => {
+		characters.forEach((doc) => {
 			expect(screen.queryByText(doc.name)).toBeInTheDocument();
 		});
 
 		done();
 	});
 
-	it('should return data in JSON format', async done => {
+	it('should support queries based on findByIds()', async () => {
+		const queriedIds = ['1', '2'];
+		const Child: FC = () => {
+			const queryConstructor = useCallback(
+				(c: RxCollection<Character>) => c.findByIds(queriedIds),
+				[]
+			);
+			const {
+				result: characters,
+				isFetching,
+				isExhausted,
+				resetList,
+			} = useRxData<Character>('characters', queryConstructor);
+
+			return (
+				<>
+					<CharacterList
+						characters={characters}
+						isFetching={isFetching}
+						isExhausted={isExhausted}
+						resetList={resetList}
+					/>
+				</>
+			);
+		};
+
+		render(
+			<Provider db={db}>
+				<Child />
+			</Provider>
+		);
+
+		// should render in loading state
+		expect(screen.getByText('loading')).toBeInTheDocument();
+		expect(screen.queryByText('isExhausted')).not.toBeInTheDocument();
+
+		// wait for data
+		await waitFor(async () => {
+			// data should now be rendered
+			characters.forEach((doc) => {
+				if (queriedIds.includes(doc.id)) {
+					expect(screen.queryByText(doc.name)).toBeInTheDocument();
+				} else {
+					expect(
+						screen.queryByText(doc.name)
+					).not.toBeInTheDocument();
+				}
+			});
+			expect(screen.getByText('loading')).not.toBeInTheDocument();
+		});
+	});
+
+	it('should return data in JSON format', async (done) => {
 		const Child: FC = () => {
 			const queryConstructor = useCallback(
 				(c: RxCollection<Character>) => c.find(),
 				[]
 			);
-			const { result: characters, isFetching, isExhausted } = useRxData<
-				Character
-			>('characters', queryConstructor, { json: true });
+			const {
+				result: characters,
+				isFetching,
+				isExhausted,
+			} = useRxData<Character>('characters', queryConstructor, {
+				json: true,
+			});
 
 			return (
 				<CharacterList
@@ -152,7 +208,7 @@ describe('useRxData', () => {
 		// wait for data
 		await waitFor(async () => {
 			// data should now be rendered
-			characters.forEach(doc => {
+			characters.forEach((doc) => {
 				expect(screen.queryByText(doc.name)).toBeInTheDocument();
 			});
 
@@ -165,7 +221,7 @@ describe('useRxData', () => {
 		done();
 	});
 
-	it('should support infinite scroll pagination', async done => {
+	it('should support infinite scroll pagination', async (done) => {
 		const pageSize = 2;
 
 		const Child: FC = () => {
@@ -210,11 +266,11 @@ describe('useRxData', () => {
 		// wait for data
 		await waitFor(async () => {
 			// first page data should now be rendered
-			characters.slice(0, pageSize).forEach(doc => {
+			characters.slice(0, pageSize).forEach((doc) => {
 				expect(screen.getByText(doc.name)).toBeInTheDocument();
 			});
 			// rest data should not be rendered
-			characters.slice(pageSize).forEach(doc => {
+			characters.slice(pageSize).forEach((doc) => {
 				expect(screen.queryByText(doc.name)).not.toBeInTheDocument();
 			});
 
@@ -241,7 +297,7 @@ describe('useRxData', () => {
 		// wait for next page data to be rendered
 		await waitFor(async () => {
 			// next page should be rendered now
-			characters.slice(pageSize, 2 * pageSize).forEach(doc => {
+			characters.slice(pageSize, 2 * pageSize).forEach((doc) => {
 				expect(screen.getByText(doc.name)).toBeInTheDocument();
 			});
 		});
@@ -265,7 +321,7 @@ describe('useRxData', () => {
 		// wait for last page data to be rendered
 		await waitFor(async () => {
 			// last page should be rendered now
-			characters.slice(2 * pageSize, 3 * pageSize).forEach(doc => {
+			characters.slice(2 * pageSize, 3 * pageSize).forEach((doc) => {
 				expect(screen.getByText(doc.name)).toBeInTheDocument();
 			});
 
@@ -290,7 +346,7 @@ describe('useRxData', () => {
 		expect(screen.getByText('current page: 3')).toBeInTheDocument();
 
 		// last page should still be rendered
-		characters.slice(2 * pageSize, 3 * pageSize).forEach(doc => {
+		characters.slice(2 * pageSize, 3 * pageSize).forEach((doc) => {
 			expect(screen.getByText(doc.name)).toBeInTheDocument();
 		});
 
@@ -309,10 +365,10 @@ describe('useRxData', () => {
 
 		await waitFor(async () => {
 			// now only first page data should be rendered
-			characters.slice(0, pageSize).forEach(doc => {
+			characters.slice(0, pageSize).forEach((doc) => {
 				expect(screen.getByText(doc.name)).toBeInTheDocument();
 			});
-			characters.slice(pageSize).forEach(doc => {
+			characters.slice(pageSize).forEach((doc) => {
 				expect(screen.queryByText(doc.name)).not.toBeInTheDocument();
 			});
 		});
@@ -333,17 +389,17 @@ describe('useRxData', () => {
 		expect(screen.getByText('current page: 1')).toBeInTheDocument();
 
 		// first page data should still be rendered
-		characters.slice(0, pageSize).forEach(doc => {
+		characters.slice(0, pageSize).forEach((doc) => {
 			expect(screen.getByText(doc.name)).toBeInTheDocument();
 		});
-		characters.slice(pageSize).forEach(doc => {
+		characters.slice(pageSize).forEach((doc) => {
 			expect(screen.queryByText(doc.name)).not.toBeInTheDocument();
 		});
 
 		done();
 	});
 
-	it('should support traditional pagination', async done => {
+	it('should support traditional pagination', async (done) => {
 		const pageSize = 2;
 
 		const Child: FC = () => {
@@ -408,11 +464,11 @@ describe('useRxData', () => {
 			expect(screen.queryByText('isExhausted')).not.toBeInTheDocument();
 
 			// selected page data should now be rendered
-			characters.slice(0, pageSize).forEach(doc => {
+			characters.slice(0, pageSize).forEach((doc) => {
 				expect(screen.getByText(doc.name)).toBeInTheDocument();
 			});
 			// rest data should not be rendered
-			characters.slice(pageSize).forEach(doc => {
+			characters.slice(pageSize).forEach((doc) => {
 				expect(screen.queryByText(doc.name)).not.toBeInTheDocument();
 			});
 
@@ -440,14 +496,14 @@ describe('useRxData', () => {
 		// wait for next page data to be rendered
 		await waitFor(async () => {
 			// next page data should now be rendered
-			characters.slice(pageSize, 2 * pageSize).forEach(doc => {
+			characters.slice(pageSize, 2 * pageSize).forEach((doc) => {
 				expect(screen.getByText(doc.name)).toBeInTheDocument();
 			});
 			// rest data should not be rendered
 			[
 				...characters.slice(0, pageSize),
 				...characters.slice(2 * pageSize),
-			].forEach(doc => {
+			].forEach((doc) => {
 				expect(screen.queryByText(doc.name)).not.toBeInTheDocument();
 			});
 
@@ -470,13 +526,13 @@ describe('useRxData', () => {
 		// should not be loading
 		expect(screen.queryByText('loading')).not.toBeInTheDocument();
 		// same data should now be rendered
-		characters.slice(pageSize, 2 * pageSize).forEach(doc => {
+		characters.slice(pageSize, 2 * pageSize).forEach((doc) => {
 			expect(screen.getByText(doc.name)).toBeInTheDocument();
 		});
 		[
 			...characters.slice(0, pageSize),
 			...characters.slice(2 * pageSize),
-		].forEach(doc => {
+		].forEach((doc) => {
 			expect(screen.queryByText(doc.name)).not.toBeInTheDocument();
 		});
 
@@ -499,15 +555,12 @@ describe('useRxData', () => {
 		done();
 	});
 
-	it('should always convert results to array', async done => {
+	it('should always convert results to array', async (done) => {
 		const idToSearchFor = '1';
 		const Child: FC = () => {
 			const queryConstructor = useCallback(
 				(c: RxCollection<Character>) =>
-					c
-						.findOne()
-						.where('id')
-						.equals('1'),
+					c.findOne().where('id').equals('1'),
 				[]
 			);
 			const {
@@ -533,7 +586,7 @@ describe('useRxData', () => {
 		);
 
 		await waitFor(async () => {
-			characters.forEach(doc => {
+			characters.forEach((doc) => {
 				if (doc.id === idToSearchFor) {
 					expect(screen.getByText(doc.name)).toBeInTheDocument();
 				} else {
@@ -547,7 +600,7 @@ describe('useRxData', () => {
 		done();
 	});
 
-	it('should handle missing query', async done => {
+	it('should handle missing query', async (done) => {
 		const Child: FC = () => {
 			const queryConstructor = useCallback(() => undefined, []);
 			const {
@@ -580,7 +633,7 @@ describe('useRxData', () => {
 		done();
 	});
 
-	it('should handle missing collection', async done => {
+	it('should handle missing collection', async (done) => {
 		const Child: FC = () => {
 			const queryConstructor = useCallback(
 				(c: RxCollection<Character>) => c.find(),
@@ -615,7 +668,7 @@ describe('useRxData', () => {
 		done();
 	});
 
-	it('should handle missing database', async done => {
+	it('should handle missing database', async (done) => {
 		const Child: FC = () => {
 			const queryConstructor = useCallback(
 				(c: RxCollection<Character>) => c.find(),
@@ -650,24 +703,23 @@ describe('useRxData', () => {
 		done();
 	});
 
-	it('should set isFetching to true whenever the query changes', async done => {
+	it('should set isFetching to true whenever the query changes', async (done) => {
 		const Child: FC = () => {
 			const [name, setName] = useState('');
 			const queryConstructor = useCallback(
 				(c: RxCollection<Character>) => {
 					if (name) {
-						return c
-							.find()
-							.where('name')
-							.equals(name);
+						return c.find().where('name').equals(name);
 					}
 					return c.find();
 				},
 				[name]
 			);
-			const { result: characters, isFetching, isExhausted } = useRxData<
-				Character
-			>('characters', queryConstructor);
+			const {
+				result: characters,
+				isFetching,
+				isExhausted,
+			} = useRxData<Character>('characters', queryConstructor);
 
 			return (
 				<>
@@ -703,7 +755,7 @@ describe('useRxData', () => {
 			expect(screen.queryByText('loading')).not.toBeInTheDocument();
 
 			// data should now be rendered
-			characters.forEach(doc => {
+			characters.forEach((doc) => {
 				expect(screen.queryByText(doc.name)).toBeInTheDocument();
 			});
 
@@ -735,8 +787,8 @@ describe('useRxData', () => {
 			// just making sure the correct data are fetched
 			expect(screen.getByText('Yoda')).toBeInTheDocument();
 			characters
-				.filter(doc => doc.name !== 'Yoda')
-				.forEach(doc => {
+				.filter((doc) => doc.name !== 'Yoda')
+				.forEach((doc) => {
 					expect(
 						screen.queryByText(doc.name)
 					).not.toBeInTheDocument();
@@ -750,26 +802,28 @@ describe('useRxData', () => {
 describe('useRxData + lazy collection init', () => {
 	let db: MyDatabase;
 
-	beforeEach(async done => {
+	beforeEach(async (done) => {
 		// create db without collection + data
 		db = await createDatabase();
 		done();
 	});
 
-	afterEach(async done => {
+	afterEach(async (done) => {
 		await teardown(db);
 		done();
 	});
 
-	it('should read data from lazily created collection', async done => {
+	it('should read data from lazily created collection', async (done) => {
 		const Child: FC = () => {
 			const queryConstructor = useCallback(
 				(c: RxCollection<Character>) => c.find(),
 				[]
 			);
-			const { result: characters, isFetching, isExhausted } = useRxData<
-				Character
-			>('characters', queryConstructor);
+			const {
+				result: characters,
+				isFetching,
+				isExhausted,
+			} = useRxData<Character>('characters', queryConstructor);
 
 			return (
 				<>
@@ -804,7 +858,7 @@ describe('useRxData + lazy collection init', () => {
 		// wait for data
 		await waitFor(async () => {
 			// data should now be rendered
-			characters.forEach(doc => {
+			characters.forEach((doc) => {
 				expect(screen.queryByText(doc.name)).toBeInTheDocument();
 			});
 		});
@@ -812,15 +866,17 @@ describe('useRxData + lazy collection init', () => {
 		done();
 	});
 
-	it('should read data from recreated collection', async done => {
+	it('should read data from recreated collection', async (done) => {
 		const Child: FC = () => {
 			const queryConstructor = useCallback(
 				(c: RxCollection<Character>) => c.find(),
 				[]
 			);
-			const { result: characters, isFetching, isExhausted } = useRxData<
-				Character
-			>('characters', queryConstructor);
+			const {
+				result: characters,
+				isFetching,
+				isExhausted,
+			} = useRxData<Character>('characters', queryConstructor);
 
 			return (
 				<>
@@ -861,12 +917,12 @@ describe('useRxData + lazy collection init', () => {
 		// wait for data
 		await waitFor(async () => {
 			// data should now be rendered
-			characters.forEach(doc => {
+			characters.forEach((doc) => {
 				expect(screen.queryByText(doc.name)).toBeInTheDocument();
 			});
 
 			// initial (now deleted) wrong characters data should not be rendered
-			wrongCharacters.forEach(doc => {
+			wrongCharacters.forEach((doc) => {
 				expect(screen.queryByText(doc.name)).not.toBeInTheDocument();
 			});
 		});


### PR DESCRIPTION
Adds support for [findByIds()](https://rxdb.info/rx-collection.html#findbyids) query. 

Things that need to be resolved before merging:
- [x] ~~Fix~~ Silence typescript issues (ts2349)
- [x] Homogenize promise/observable result handling
- [x] Does pagination make sense when using findByIds()? **Answer**: **No, pagination is ignored when using findByIds()**
- [x] Abort promise on component cleanup (aka handle component unmount before promise resolves)
- [x] Get to 100% coverage

Fixes #46 