### PR TITLE
Support RxDB 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
 		"react-dom": "^17.0.2",
 		"react-test-renderer": "^17.0.2",
 		"rimraf": "^3.0.2",
-		"rxdb": "^11.1.0",
-		"rxjs": "^7.5.1",
+		"rxdb": "^12.4.3",
+		"rxjs": "^7.5.4",
 		"shelljs": "^0.8.4",
 		"ts-jest": "^26.0.0",
 		"typescript": "^4.5.4"
@@ -62,7 +62,7 @@
 		"react": ">=16.8",
 		"react-dom": ">=16.8",
 		"rxdb": ">=10",
-		"rxjs": ">=7.4"
+		"rxjs": ">=7.5.4"
 	},
 	"resolutions": {
 		"minimist": "1.2.5"

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -7,7 +7,7 @@ export type RxDatabaseBaseExtended<
 	Internals = any,
 	Options = any
 > = RxDatabaseBase<Internals, Options> & {
-	newCollections$: Subject<CollectionRecord>;
+	newCollections$?: Subject<CollectionRecord>;
 };
 
 /**

--- a/src/useRxDocument.ts
+++ b/src/useRxDocument.ts
@@ -53,8 +53,12 @@ function useRxDocument<T>(
 	 * don't return a valid RxQuery object
 	 */
 	const queryConstructor = useCallback(
-		(c: RxCollection<T>) =>
-			id ? c.findOne().where(preferredIdAttribute).equals(id) : undefined,
+		(c: RxCollection<T>) => {
+			if (!id) {
+				return undefined;
+			}
+			return c.findOne({ selector: { [preferredIdAttribute]: id } });
+		},
 		[id, preferredIdAttribute]
 	);
 

--- a/tests/useRxData.test.tsx
+++ b/tests/useRxData.test.tsx
@@ -10,11 +10,14 @@ import {
 	delay,
 } from './helpers';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import { RxCollection } from 'rxdb';
+import { addRxPlugin, RxCollection } from 'rxdb';
+import { RxDBQueryBuilderPlugin } from 'rxdb/plugins/query-builder';
 import useRxData from '../src/useRxData';
 import Provider from '../src/Provider';
 import { characters } from './mockData';
 import { act } from 'react-dom/test-utils';
+
+addRxPlugin(RxDBQueryBuilderPlugin);
 
 describe('useRxData', () => {
 	let db: MyDatabase;

--- a/tests/useRxDocument.test.tsx
+++ b/tests/useRxDocument.test.tsx
@@ -30,7 +30,7 @@ describe('useRxDocument', () => {
 		};
 
 		render(
-			<Provider db={db}>
+			<Provider db={db} idAttribute="id">
 				<Child />
 			</Provider>
 		);
@@ -59,7 +59,7 @@ describe('useRxDocument', () => {
 		};
 
 		render(
-			<Provider db={db}>
+			<Provider db={db} idAttribute="id">
 				<Child />
 			</Provider>
 		);
@@ -78,7 +78,7 @@ describe('useRxDocument', () => {
 
 	it('should allow lazy evaluation of id', async done => {
 		const Child: FC = () => {
-			const [id, setId] = useState(undefined);
+			const [id, setId] = useState<string>();
 
 			const { result: character, isFetching } = useRxDocument<Character>(
 				'characters',
@@ -98,7 +98,7 @@ describe('useRxDocument', () => {
 		};
 
 		render(
-			<Provider db={db} idAttribute="_id">
+			<Provider db={db} idAttribute="id">
 				<Child />
 			</Provider>
 		);
@@ -251,14 +251,14 @@ describe('useRxDocument', () => {
 		};
 
 		const App: FC = () => {
-			const [lazyDb, setLazyDb] = useState(null);
+			const [lazyDb, setLazyDb] = useState<MyDatabase>();
 
 			const handleInit = () => {
 				setLazyDb(db);
 			};
 
 			return (
-				<Provider db={lazyDb}>
+				<Provider db={lazyDb} idAttribute="id">
 					<Child />
 					<button onClick={handleInit}>init</button>
 				</Provider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -241,10 +241,10 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/runtime@7.16.7", "@babel/runtime@^7.12.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.9.2":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.7.tgz#03ff99f64106588c9c403c6ecb8c3bafbbdff1fa"
-  integrity sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==
+"@babel/runtime@7.18.3":
+  version "7.18.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.3.tgz#c7b654b57f6f63cf7f8b418ac9ca04408c4579f4"
+  integrity sha512-38Y8f7YUhce/K7RMwTp7m0uCumpv9hZkitCbBClqQIow1qSbCvGkcegKOXpEWCQLfWmevgRiWokZ1GkpfhbZug==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -252,6 +252,13 @@
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.6.tgz#a9102eb5cadedf3f31d08a9ecf294af7827ea29f"
   integrity sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.9.2":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.7.tgz#03ff99f64106588c9c403c6ecb8c3bafbbdff1fa"
+  integrity sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -837,10 +844,10 @@
     "@types/node-fetch" "*"
     "@types/pouchdb-find" "*"
 
-"@types/pouchdb-core@7.0.9":
-  version "7.0.9"
-  resolved "https://registry.yarnpkg.com/@types/pouchdb-core/-/pouchdb-core-7.0.9.tgz#9fecde62e54562c054abf8a4f72cbc0f9ac1e8ae"
-  integrity sha512-zzO8wkTztn1wT//mxIpcxSuKWlrHbVeERnPKVNEi9mbuqyLqevH+kRaGCJaEjwLp/tVjwnM/e6ZJoFsdP90pQg==
+"@types/pouchdb-core@7.0.10":
+  version "7.0.10"
+  resolved "https://registry.yarnpkg.com/@types/pouchdb-core/-/pouchdb-core-7.0.10.tgz#d1ea1549e7fad6cb579f71459b1bc27252e06a5a"
+  integrity sha512-mKhjLlWWXyV3PTTjDhzDV1kc2dolO7VYFa75IoKM/hr8Er9eo8RIbS7mJLfC8r/C3p6ihZu9yZs1PWC1LQ0SOA==
   dependencies:
     "@types/debug" "*"
     "@types/pouchdb-find" "*"
@@ -1047,13 +1054,13 @@ abstract-leveldown@~6.2.1:
     level-supports "~1.0.0"
     xtend "~4.0.0"
 
-accepts@~1.3.7:
-  version "1.3.7"
-  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
-  integrity sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==
+accepts@~1.3.8:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
+  integrity sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==
   dependencies:
-    mime-types "~2.1.24"
-    negotiator "0.6.2"
+    mime-types "~2.1.34"
+    negotiator "0.6.3"
 
 acorn-globals@^6.0.0:
   version "6.0.0"
@@ -1225,10 +1232,10 @@ array-includes@^3.1.3, array-includes@^3.1.4:
     get-intrinsic "^1.1.1"
     is-string "^1.0.7"
 
-array-push-at-sort-position@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/array-push-at-sort-position/-/array-push-at-sort-position-1.2.0.tgz#df6c03d4a4c30d5af5537a5a8228ebb9442d89fc"
-  integrity sha512-33YkzjLE7OT+o/idj+n27YFau2NwGxMBN+lLkFpRnQJe4EkJntLY0z4YYfLRBZrqG7lixDk4Rt2iSC10CEmZsQ==
+array-push-at-sort-position@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/array-push-at-sort-position/-/array-push-at-sort-position-2.0.0.tgz#1e074ac26edb731397fd1e9a7d4213d50255df45"
+  integrity sha512-ql0VKuKrho2TCC0dRSt0MBZtoXxB1DazRFo5gO/r29O2lAT2hgP2rnS8j7aLzqP4Ig15VQhyRN1cOU2hd/+jkw==
 
 array-union@^2.1.0:
   version "2.1.0"
@@ -1390,20 +1397,20 @@ binary-decision-diagram@1.4.0:
   resolved "https://registry.yarnpkg.com/binary-decision-diagram/-/binary-decision-diagram-1.4.0.tgz#ad141f0eec7bf3e57d00b1bc0437f97cb322fcd4"
   integrity sha512-qRUz4Hhuc3kegR6X5cNLPOkosNRv0ToYjTkTxb9ecNjS3MtIVllaheJoxyqm1ZFDJ22cBAnkwmJF4ZdXyxSbxg==
 
-body-parser@1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.1.tgz#1499abbaa9274af3ecc9f6f10396c995943e31d4"
-  integrity sha512-8ljfQi5eBk8EJfECMrgqNGWPEY5jWP+1IzkzkGdFFEwFQZZyaZ21UqdaHktgiMlH0xLHqIFtE/u2OYE5dOtViA==
+body-parser@1.19.2:
+  version "1.19.2"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.2.tgz#4714ccd9c157d44797b8b5607d72c0b89952f26e"
+  integrity sha512-SAAwOxgoCKMGs9uUAUFHygfLAyaniaoun6I8mFY9pRAJL9+Kec34aU+oIjDhTycub1jozEfEwx1W1IuOYxVSFw==
   dependencies:
-    bytes "3.1.1"
+    bytes "3.1.2"
     content-type "~1.0.4"
     debug "2.6.9"
     depd "~1.1.2"
     http-errors "1.8.1"
     iconv-lite "0.4.24"
     on-finished "~2.3.0"
-    qs "6.9.6"
-    raw-body "2.4.2"
+    qs "6.9.7"
+    raw-body "2.4.3"
     type-is "~1.6.18"
 
 brace-expansion@^1.1.7:
@@ -1437,10 +1444,10 @@ braces@^3.0.1:
   dependencies:
     fill-range "^7.0.1"
 
-broadcast-channel@4.9.0:
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-4.9.0.tgz#8af337d4ea19aeb6b819ec2eb3dda942b28c724c"
-  integrity sha512-xWzFb3wrOZGJF2kOSs2D3KvHXdLDMVb+WypEIoNvwblcHgUBydVy65pDJ9RS4WN9Kyvs0UVQuCCzfKme0G6Qjw==
+broadcast-channel@4.10.0:
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-4.10.0.tgz#d19fb902df227df40b1b580351713d30c302d198"
+  integrity sha512-hOUh312XyHk6JTVyX9cyXaH1UYs+2gHVtnW16oQAu9FL7ALcXGXc/YoJWqlkV8vUn14URQPMmRi4A9q4UrwVEQ==
   dependencies:
     "@babel/runtime" "^7.16.0"
     detect-node "^2.1.0"
@@ -1499,10 +1506,10 @@ buffer@^5.5.0, buffer@^5.6.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
-bytes@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.1.tgz#3f018291cb4cbad9accb6e6970bca9c8889e879a"
-  integrity sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg==
+bytes@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
+  integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
 cache-base@^1.0.1:
   version "1.0.1"
@@ -1672,15 +1679,15 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.5.0, commander@^2.7.1:
+commander@^2.20.3, commander@^2.5.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-common-tags@1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.0.tgz#8e3153e542d4a39e9b10554434afaaf98956a937"
-  integrity sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==
+common-tags@1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.2.tgz#94ebb3c076d26032745fd54face7f688ef5ac9c6"
+  integrity sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==
 
 commoner@^0.10.1:
   version "0.10.8"
@@ -1736,10 +1743,10 @@ cookie-signature@1.0.6:
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
 
-cookie@0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
-  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
+cookie@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
 
 copy-descriptor@^0.1.0:
   version "0.1.1"
@@ -1903,10 +1910,10 @@ deepmerge@^4.2.2:
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
 
-defekt@7.3.3:
-  version "7.3.3"
-  resolved "https://registry.yarnpkg.com/defekt/-/defekt-7.3.3.tgz#042e0e1164c28d0276c8f2168c305a4281f4a9f6"
-  integrity sha512-IVSwlS50EZosgrtIXruq9blDFzB9MsFvbl8Ty1L33va8a2tgRVWJYDWUhvWZpBPwr5VKGDCiZR+o2/PbuuITOQ==
+defekt@8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/defekt/-/defekt-8.2.0.tgz#678196737f7f01750fb26cf061e8f51812d04bc4"
+  integrity sha512-U8Tt5XKQ+4ENgSU6bc4Muww1shqPLex74ao26Z9w4FBFn5Dc0hu9VtRq6opzBacD/nvIJQv7azapP7Ex39OJNw==
 
 deferred-leveldown@~5.3.0:
   version "5.3.0"
@@ -1982,6 +1989,11 @@ detective@^4.3.1:
   dependencies:
     acorn "^5.2.1"
     defined "^1.0.0"
+
+dexie@4.0.0-alpha.3:
+  version "4.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/dexie/-/dexie-4.0.0-alpha.3.tgz#0f8ee594a3015329414fae1f64ef8d62b96871a4"
+  integrity sha512-IMrOTfBQjmu5MKzkCPeGQcdu3LILtwMYfZIdHHQpRAtXxM+8NNKmXZsv25XGAz5eabAniB0pDA//EfsjtmiBWg==
 
 diff-sequences@^25.2.6:
   version "25.2.6"
@@ -2374,12 +2386,12 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
-event-reduce-js@2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/event-reduce-js/-/event-reduce-js-2.0.3.tgz#b1b77f68746a179697d34943a7a3aeaa77179922"
-  integrity sha512-kSSS36hXK+VCiJvRPuj0aFFhdE4ww11I/DUbfVXD69qi+umtDweXQKjHqYwl3lvgLxpZDlHmZlxkV1IPFli0pw==
+event-reduce-js@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/event-reduce-js/-/event-reduce-js-2.0.4.tgz#f26230099f882899be5831005b33a89e4a215f2f"
+  integrity sha512-PBo0hZ+/1BkDw0te5qwzRLWVgfQ8Emcv3TN9zYxT1jl18XHtEw3vvKLR7qvXqgE7kzO4270KKtRuuPilXwTiiQ==
   dependencies:
-    array-push-at-sort-position "1.2.0"
+    array-push-at-sort-position "2.0.0"
     binary-decision-diagram "1.4.0"
     object-path "0.11.8"
 
@@ -2456,17 +2468,17 @@ expect@^26.6.2:
     jest-message-util "^26.6.2"
     jest-regex-util "^26.0.0"
 
-express@4.17.2:
-  version "4.17.2"
-  resolved "https://registry.yarnpkg.com/express/-/express-4.17.2.tgz#c18369f265297319beed4e5558753cc8c1364cb3"
-  integrity sha512-oxlxJxcQlYwqPWKVJJtvQiwHgosH/LrLSPA+H4UxpyvSS6jC5aH+5MoHFM+KABgTOt0APue4w66Ha8jCUo9QGg==
+express@4.17.3:
+  version "4.17.3"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.17.3.tgz#f6c7302194a4fb54271b73a1fe7a06478c8f85a1"
+  integrity sha512-yuSQpz5I+Ch7gFrPCk4/c+dIBKlQUxtgwqzph132bsT6qhuzss6I8cLJQz7B3rFblzd6wtcI0ZbGltH/C4LjUg==
   dependencies:
-    accepts "~1.3.7"
+    accepts "~1.3.8"
     array-flatten "1.1.1"
-    body-parser "1.19.1"
+    body-parser "1.19.2"
     content-disposition "0.5.4"
     content-type "~1.0.4"
-    cookie "0.4.1"
+    cookie "0.4.2"
     cookie-signature "1.0.6"
     debug "2.6.9"
     depd "~1.1.2"
@@ -2481,7 +2493,7 @@ express@4.17.2:
     parseurl "~1.3.3"
     path-to-regexp "0.1.7"
     proxy-addr "~2.0.7"
-    qs "6.9.6"
+    qs "6.9.7"
     range-parser "~1.2.1"
     safe-buffer "5.2.1"
     send "0.17.2"
@@ -2721,15 +2733,15 @@ get-caller-file@^2.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-graphql-from-jsonschema@8.0.16:
-  version "8.0.16"
-  resolved "https://registry.yarnpkg.com/get-graphql-from-jsonschema/-/get-graphql-from-jsonschema-8.0.16.tgz#479760abc08bd95a00d46ec58e15653a08bb732a"
-  integrity sha512-iwbywzMKyd2v547YH5zJ3eeEf6QHucvdUR3Lk/vfyhq5zY3t5oUx79hdBLrXEldql7/gQl/t7BWTr/WM79U3Wg==
+get-graphql-from-jsonschema@8.0.17:
+  version "8.0.17"
+  resolved "https://registry.yarnpkg.com/get-graphql-from-jsonschema/-/get-graphql-from-jsonschema-8.0.17.tgz#1b834ce8a8c53e1149df20f758e2ba40d58cff1c"
+  integrity sha512-uYFg4vZZy0IAF07sXS0xyMesuInqvaAl7bNZDrhzt1a1E5lz0evpiJoL5NN1BmAP14LXFogj5H49q6uncZaISw==
   dependencies:
     "@types/common-tags" "1.8.1"
     "@types/json-schema" "7.0.9"
-    common-tags "1.8.0"
-    defekt "7.3.3"
+    common-tags "1.8.2"
+    defekt "8.2.0"
 
 get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
   version "1.1.1"
@@ -4290,6 +4302,11 @@ mime-db@1.51.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
   integrity sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
 mime-types@^2.1.12:
   version "2.1.34"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.34.tgz#5a712f9ec1503511a945803640fafe09d3793c24"
@@ -4303,6 +4320,13 @@ mime-types@~2.1.24:
   integrity sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==
   dependencies:
     mime-db "1.44.0"
+
+mime-types@~2.1.34:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
 
 mime@1.6.0:
   version "1.6.0"
@@ -4318,6 +4342,11 @@ min-indent@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
+
+mingo@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/mingo/-/mingo-5.1.0.tgz#dce013ef4891e138865f4ab7d8e7be3dc3268bd6"
+  integrity sha512-8sLvtWBi8xZQDuMQtfg54hTMVgpUAYWaPLhvBLInJLCsKPJ9SxtOj/WCA9A9ESItR+RBDoNnDbpXPaGYQMb4CA==
 
 "minimatch@2 || 3", minimatch@^3.0.4:
   version "3.0.4"
@@ -4419,10 +4448,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-negotiator@0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
-  integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
+negotiator@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
+  integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -5188,10 +5217,10 @@ q@^1.1.2:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
-qs@6.9.6:
-  version "6.9.6"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.6.tgz#26ed3c8243a431b2924aca84cc90471f35d5a0ee"
-  integrity sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==
+qs@6.9.7:
+  version "6.9.7"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.7.tgz#4610846871485e1e048f44ae3b94033f0e675afe"
+  integrity sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==
 
 querystring@0.2.0:
   version "0.2.0"
@@ -5208,12 +5237,12 @@ range-parser@~1.2.1:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
-raw-body@2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.4.2.tgz#baf3e9c21eebced59dd6533ac872b71f7b61cb32"
-  integrity sha512-RPMAFUJP19WIet/99ngh6Iv8fzAbqum4Li7AD6DtGaW2RpMB/11xDoalPiJMTbu6I3hkbMVkATvZrqb9EEqeeQ==
+raw-body@2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.4.3.tgz#8f80305d11c2a0a545c2d9d89d7a0286fcead43c"
+  integrity sha512-UlTNLIcu0uzb4D2f4WltY6cVjLi+/jEN4lgEUj3E04tpMDpUlkBo/eSn6zou9hum2VMNpCCUone0O0WeJim07g==
   dependencies:
-    bytes "3.1.1"
+    bytes "3.1.2"
     http-errors "1.8.1"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
@@ -5460,37 +5489,40 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-rxdb@^11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/rxdb/-/rxdb-11.1.0.tgz#06a0189510541754545478329c5771754d19991e"
-  integrity sha512-2Ljp0PYFHQkfWDe0X9vzk9S6eop6z62EtKBjx+CU7T+/y5CeP6QCTJlDUzqFo4BhswjE/W6hQNcfncGByyaOpw==
+rxdb@^12.4.3:
+  version "12.4.3"
+  resolved "https://registry.yarnpkg.com/rxdb/-/rxdb-12.4.3.tgz#e3163da4e6acc06d5809a1fd926a2590021bb776"
+  integrity sha512-mW3eGNU+JPgX2SdrQMd4a52GL7PWwEIAEzj1cPEeNgKZsJZuIHeAx9VpAEGBA6XF+MuYeHN1A1h/5AiCtF7F6Q==
   dependencies:
-    "@babel/runtime" "7.16.7"
+    "@babel/runtime" "7.18.3"
     "@types/clone" "2.1.1"
     "@types/cors" "2.8.12"
     "@types/express" "4.17.13"
     "@types/is-my-json-valid" "2.18.0"
     "@types/lokijs" "1.5.7"
     "@types/object-path" "0.11.1"
-    "@types/pouchdb-core" "7.0.9"
+    "@types/pouchdb-core" "7.0.10"
     "@types/spark-md5" "3.0.2"
+    array-push-at-sort-position "2.0.0"
     as-typed "1.3.2"
     babel-plugin-transform-async-to-promises "0.8.18"
-    broadcast-channel "4.9.0"
+    broadcast-channel "4.10.0"
     clone "^2.1.2"
     cors "2.8.5"
     crypto-js "4.1.1"
     custom-idle-queue "3.0.1"
     deep-freeze "0.0.1"
-    event-reduce-js "2.0.3"
-    express "4.17.2"
+    dexie "4.0.0-alpha.3"
+    event-reduce-js "2.0.4"
+    express "4.17.3"
     fast-deep-equal "3.1.3"
-    get-graphql-from-jsonschema "8.0.16"
+    get-graphql-from-jsonschema "8.0.17"
     graphql-client "2.0.1"
     is-electron "2.2.0"
     is-my-json-valid "2.20.6"
     jsonschema-key-compression "1.6.1"
     lokijs "1.5.12"
+    mingo "5.1.0"
     modifyjs "0.3.1"
     object-path "0.11.8"
     oblivious-set "1.0.0"
@@ -5506,12 +5538,12 @@ rxdb@^11.1.0:
     unload "2.3.1"
     url "^0.11.0"
     util "0.12.4"
-    z-schema "5.0.2"
+    z-schema "5.0.3"
 
-rxjs@^7.5.1:
-  version "7.5.1"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.1.tgz#af73df343cbcab37628197f43ea0c8256f54b157"
-  integrity sha512-KExVEeZWxMZnZhUZtsJcFwz8IvPvgu4G2Z2QyqjZQzUGr32KDYuSxrEYO4w3tFFNbfLozcrKUTvTPi+E9ywJkQ==
+rxjs@^7.5.4:
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.5.tgz#2ebad89af0f560f460ad5cc4213219e1f7dd4e9f"
+  integrity sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==
   dependencies:
     tslib "^2.1.0"
 
@@ -6554,13 +6586,13 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-z-schema@5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/z-schema/-/z-schema-5.0.2.tgz#f410394b2c9fcb9edaf6a7511491c0bb4e89a504"
-  integrity sha512-40TH47ukMHq5HrzkeVE40Ad7eIDKaRV2b+Qpi2prLc9X9eFJFzV7tMe5aH12e6avaSS/u5l653EQOv+J9PirPw==
+z-schema@5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/z-schema/-/z-schema-5.0.3.tgz#68fafb9b735fc7f3c89eabb3e5a6353b4d7b4935"
+  integrity sha512-sGvEcBOTNum68x9jCpCVGPFJ6mWnkD0YxOcddDlJHRx3tKdB2q8pCHExMVZo/AV/6geuVJXG7hljDaWG8+5GDw==
   dependencies:
     lodash.get "^4.4.2"
     lodash.isequal "^4.5.0"
     validator "^13.7.0"
   optionalDependencies:
-    commander "^2.7.1"
+    commander "^2.20.3"


### PR DESCRIPTION
Minor fixes that enable `rxdb-hooks` to work with `rxdb@12.x`. Fixes are backwards compatible with older versions. 

- [x] ~drop `useRxDocument`~  remove `useRxDocument`'s reliance on chained queries
- [x] fix `observeNewCollections` plugin compatibility issues
- [x] use `RxDBQueryBuilderPlugin` for testing

Closes #52.