### PR TITLE
Support for lazy collection creation made opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,23 @@ const { result } = useRxData('characters', queryConstructor);
 
 All rxdb-hooks give you the ability to lazily instantiate the database and the
 collections within it. Initial delay until the above become available is absorbed
-by indicating the state as fetching (`isFetching:true`)
+by indicating the state as fetching (`isFetching:true`).
+
+Since `v5.0.0` of `rxdb-hooks`, observing newly created collections has become
+an **opt-in** feature that, _if needed_, has to be enabled via the provided `observeNewCollections` plugin:
+
+```javascript
+import { addRxPlugin } from 'rxdb';
+import { observeNewCollections } from 'rxdb-hooks';
+
+addRxPlugin(observeNewCollections);
+```
+
+Adding the plugin makes it possible for all rxdb-hooks to pick up data from
+collections that are lazily added after the inital db initialization.
+
+Also note that lazily instantiating the rxdb instance itself is supported
+out-of-the-box, **the plugin only affects lazy collection creation**.
 
 ### Mutations
 

--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -1,16 +1,11 @@
 import React, { useMemo, PropsWithChildren } from 'react';
-import { RxDatabase, addRxPlugin } from 'rxdb';
+import { RxDatabase } from 'rxdb';
 import Context from './context';
-import { observeNewCollections, RxDatabaseBaseExtended } from './plugins';
+import { RxDatabaseBaseExtended } from './plugins';
 
 export interface ProviderProps<Collections = any> {
 	db?: RxDatabase<Collections>;
 }
-
-/**
- * TODO: Leave the plugin instantiation to the consumer (breaking change).
- */
-addRxPlugin(observeNewCollections);
 
 const Provider = <C extends unknown>({
 	db,

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,3 +10,4 @@ export { default as useRxDB } from './useRxDB';
 export * from './useRxDB';
 export { default as useRxQuery } from './useRxQuery';
 export * from './useRxQuery';
+export * from './plugins';

--- a/tests/lazy.test.tsx
+++ b/tests/lazy.test.tsx
@@ -8,11 +8,14 @@ import {
 	MyDatabase,
 } from './helpers';
 import { render, screen, waitFor } from '@testing-library/react';
-import { RxCollection } from 'rxdb';
+import { RxCollection, addRxPlugin } from 'rxdb';
 import useRxData from '../src/useRxData';
 import Provider from '../src/Provider';
+import { observeNewCollections } from '../src/plugins';
 import { characters } from './mockData';
 import { act } from 'react-dom/test-utils';
+
+addRxPlugin(observeNewCollections);
 
 describe('useRxData + lazy collection init', () => {
 	let db: MyDatabase;


### PR DESCRIPTION
Observing newly created collections has become an **opt-in** feature that, _if needed_, has to be enabled via the provided `observeNewCollections` plugin:

```javascript
import { addRxPlugin } from 'rxdb';
import { observeNewCollections } from 'rxdb-hooks';

addRxPlugin(observeNewCollections);
```