### PR TITLE
Fix confusing lowercased `jedi` in query

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ const collection = useRxCollection('characters');
 
 const query = collection.find({
   selector: {
-    affiliation: 'jedi',
+    affiliation: 'Jedi',
   },
 });
 


### PR DESCRIPTION
The query should `"Jedi"` instead of `"jedi"` in the sample query on the README -- otherwise, no documents are returned which can be confusing to the end user (i.e., I got stuck on this thinking my config was broken for the past 20 min 😛 )