### PR TITLE
docs: mention official RxDB react-hooks plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 #### React hooks for integrating with [RxDB](https://github.com/pubkey/rxdb)
 
+> [!NOTE]
+> Since [`17.0.0-beta.7`](https://rxdb.info/releases/17.0.0.html), RxDB ships its own official React hooks plugin — see the [RxDB React integration guide](https://rxdb.info/react.html). If you're starting a new project on RxDB ≥ 17, the official plugin is the recommended choice. `rxdb-hooks` continues to be maintained for projects on the RxDB versions listed in the [compatibility table](#compatibility-with-rxdb) below.
+
 <a href="https://www.npmjs.com/package/rxdb-hooks">
   <img src="https://img.shields.io/npm/v/rxdb-hooks?color=%23E6008D&style=flat-square" alt="npm version">
 </a>


### PR DESCRIPTION
Adds a top-of-README note pointing users to RxDB's [official React hooks plugin](https://rxdb.info/react.html) (shipped since 17.0.0-beta.7), while making clear that `rxdb-hooks` remains maintained for the RxDB versions listed in the compatibility table.

Rendered preview of the note:

> **Note**
> Since `17.0.0-beta.7`, RxDB ships its own official React hooks plugin — see the RxDB React integration guide. If you're starting a new project on RxDB ≥ 17, the official plugin is the recommended choice. `rxdb-hooks` continues to be maintained for projects on the RxDB versions listed in the compatibility table below.

Closes #90